### PR TITLE
Add optional timestamp to logs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -38,8 +38,8 @@ const userConfig = finder(projectPath).next().value.timber
  *
  * @param {String} metadata_delimiter - delimiter between log message and log data (@metadata by default)
  * @param {boolean} append_metadata - append @metadata { ... } to all logs (on by default)
- * @param {Writable} debug_logger - a writeable stream for internal debug messages to be sent to (disabled when underined)
- * @param {Writable} timestamp_prefix - When `true`, log output should be prefixed with a timestamp in ISO 8601 format (disabled when underined)
+ * @param {Writable} debug_logger - a writeable stream for internal debug messages to be sent to (disabled when undefined)
+ * @param {boolean} timestamp_prefix - When `true`, log output should be prefixed with a timestamp in ISO 8601 format (on by default)
  * @param {boolean} capture_request_body - whether the http request body data will be captured (off by default)
  * @param {boolean} capture_request_body - whether the http response body data will be captured (off by default)
  */

--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,7 @@ const userConfig = finder(projectPath).next().value.timber
  * @param {String} metadata_delimiter - delimiter between log message and log data (@metadata by default)
  * @param {boolean} append_metadata - append @metadata { ... } to all logs (on by default)
  * @param {Writable} debug_logger - a writeable stream for internal debug messages to be sent to (disabled when underined)
+ * @param {Writable} timestamp_prefix - When `true`, log output should be prefixed with a timestamp in ISO 8601 format (disabled when underined)
  * @param {boolean} capture_request_body - whether the http request body data will be captured (off by default)
  * @param {boolean} capture_request_body - whether the http response body data will be captured (off by default)
  */
@@ -46,6 +47,7 @@ const config = {
   metadata_delimiter: '@metadata',
   append_metadata: true,
   debug_logger: undefined,
+  timestamp_prefix: true,
   capture_request_body: false,
   capture_response_body: false,
   ...userConfig,

--- a/src/config.js
+++ b/src/config.js
@@ -39,7 +39,7 @@ const userConfig = finder(projectPath).next().value.timber
  * @param {String} metadata_delimiter - delimiter between log message and log data (@metadata by default)
  * @param {boolean} append_metadata - append @metadata { ... } to all logs (on by default)
  * @param {Writable} debug_logger - a writeable stream for internal debug messages to be sent to (disabled when undefined)
- * @param {boolean} timestamp_prefix - When `true`, log output should be prefixed with a timestamp in ISO 8601 format (on by default)
+ * @param {boolean} timestamp_prefix - When `true`, log output should be prefixed with a timestamp in ISO 8601 format (off by default)
  * @param {boolean} capture_request_body - whether the http request body data will be captured (off by default)
  * @param {boolean} capture_request_body - whether the http response body data will be captured (off by default)
  */
@@ -47,7 +47,7 @@ const config = {
   metadata_delimiter: '@metadata',
   append_metadata: true,
   debug_logger: undefined,
-  timestamp_prefix: true,
+  timestamp_prefix: false,
   capture_request_body: false,
   capture_response_body: false,
   ...userConfig,

--- a/src/log.js
+++ b/src/log.js
@@ -13,7 +13,8 @@ class Log {
    */
   constructor(message, context = {}) {
     // Throw an error if no message is provided
-    if (!message) throw new Error('You must supply a message when creating a log')
+    if (!message)
+      throw new Error('You must supply a message when creating a log')
 
     /**
      * Reference to original log message
@@ -59,12 +60,19 @@ class Log {
    * i.e. `Log message @metadata { ... }`
    */
   format({ withMetadata = true } = {}) {
+    const { dt, ...rest } = this.data
+
     let message = this.raw.endsWith('\n')
       ? this.raw.substring(0, this.raw.length - 1)
       : this.raw
 
+    if (config.timestamp_prefix) {
+      message = `${dt.toISOString()} ${message}`
+    }
+
     if (withMetadata) {
-      message += ` ${config.metadata_delimiter} ${JSON.stringify(this.data)}`
+      const data = config.timestamp_prefix ? rest : { dt, ...rest }
+      message += ` ${config.metadata_delimiter} ${JSON.stringify(data)}`
     }
 
     return `${message}\n`


### PR DESCRIPTION
Add configuration option for `timestamp_prefix` (offby default). When enabled, all log lines will get prefixed with an ISO timestamp and the `dt` key removed from the metadata object.

Sample output with `timestamp_prefix` enabled:

```
2017-06-26T19:53:16.968Z Listening at http://localhost:8080 @metadata {"$schema":"https://raw.githubusercontent.com/timberio/log-event-json-schema/1.2.3/schema.json","message":"Listening at http://localhost:8080\n","level":"info"}
2017-06-26T19:54:11.451Z Started GET "/domain/timber.io/status" @metadata {"$schema":"https://raw.githubusercontent.com/timberio/log-event-json-schema/1.2.3/schema.json","message":"Started GET \"/domain/timber.io/status\"","context":{"http":{"method":"GET","path":"/domain/timber.io/status","remote_addr":"::1","request_id":"36cad537-7580-47ae-abb3-271640a5fd83"}},"event":{"server_side_app":{"http_server_request":{"host":"localhost:8080","method":"GET","path":"/domain/timber.io/status","request_id":"36cad537-7580-47ae-abb3-271640a5fd83","scheme":"http"}}},"level":"info"}
2017-06-26T19:54:11.589Z Outgoing HTTP response 304 in 142ms @metadata {"$schema":"https://raw.githubusercontent.com/timberio/log-event-json-schema/1.2.3/schema.json","message":"Outgoing HTTP response 304 in 142ms","context":{"http":{"method":"GET","path":"/domain/timber.io/status","remote_addr":"::1","request_id":"36cad537-7580-47ae-abb3-271640a5fd83"}},"event":{"server_side_app":{"http_server_response":{"body":"{\"domain\":{\"name\":\"timber.io\",\"status\":\"taken\"}}","request_id":"36cad537-7580-47ae-abb3-271640a5fd83","status":304,"time_ms":142}}},"level":"info"}
```

To change the setting:

```js
const timber = require('timber');

timber.config.timestamp_prefix = true;
```

