### PR TITLE
Preserve original console functions until attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
-Please see [https://github.com/timberio/timber-node/releases](https://github.com/timberio/timber-node/releases) for library specific changes.
+All notable changes to this project will be documented in this file.
 
-For all Timber changes see [https://timber.io/changelog](https://timber.io/changelog).
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+  - The built in `console` functions are no longer patched on import
+
+### Changed
+
+  - To append metadata without installing a transport, you must set `timber.config.append_metadata = true`
+
+[Unreleased]: https://github.com/timberio/timber-node/compare/v2.1.1...HEAD

--- a/src/config.js
+++ b/src/config.js
@@ -42,6 +42,8 @@ const userConfig = finder(projectPath).next().value.timber
  * @param {boolean} timestamp_prefix - When `true`, log output should be prefixed with a timestamp in ISO 8601 format (off by default)
  */
 const config = {
+  _attached_stdout: false,
+  _attached_stderr: false,
   logger: console,
   metadata_delimiter: '@metadata',
   append_metadata: false,

--- a/src/console.js
+++ b/src/console.js
@@ -37,20 +37,29 @@ const transformConsoleLog = ({ args, level }) => {
   return log.format()
 }
 
-console.info = (...args) => {
-  process.stdout.write(transformConsoleLog({ args, level: 'info' }))
+const originalConsole = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error
 }
 
-console.log = (...args) => {
-  process.stdout.write(transformConsoleLog({ args, level: 'info' }))
-}
+console.log = (...args) =>
+  config._attached_stdout || config.append_metadata
+    ? process.stdout.write(transformConsoleLog({ args, level: 'info' }))
+    : originalConsole.log(...args)
 
-console.warn = (...args) => {
-  process.stdout.write(transformConsoleLog({ args, level: 'warn' }))
-}
+console.info = (...args) =>
+  config._attached_stdout || config.append_metadata
+    ? process.stdout.write(transformConsoleLog({ args, level: 'info' }))
+    : originalConsole.info(...args)
 
-console.error = (...args) => {
-  process.stderr.write(transformConsoleLog({ args, level: 'error' }))
-}
+console.warn = (...args) =>
+  config._attached_stdout || config.append_metadata
+    ? process.stdout.write(transformConsoleLog({ args, level: 'warn' }))
+    : originalConsole.warn(...args)
 
-export default console
+console.error = (...args) =>
+  config._attached_stderr || config.append_metadata
+    ? process.stderr.write(transformConsoleLog({ args, level: 'error' }))
+    : originalConsole.error(...args)

--- a/src/utils/attach.js
+++ b/src/utils/attach.js
@@ -52,6 +52,12 @@ const attach = (transports, toStream, { applyBackPressure = false } = {}) => {
     ])
   }
 
+  if (toStream === process.stdout) {
+    config._attached_stdout = true
+  } else if (toStream === process.stderr) {
+    config._attached_stderr = true
+  }
+
   return {
     detach: () => {
       toStream.write = originalWrite


### PR DESCRIPTION
So after a lot of trial and error I pinged the node irc channel to figure out why overriding the entire console object at once instead of individual keys wasn't working.

Apparently the `console` object is immutable in a sense. You can override individual keys like `console.info = (...args) => process.stdout.write(...args)`, but overriding the entire `console` object at once is impossible.

So unfortunately there's no convenient way for the user to explicitly override the console like we discussed. The only way it would be possible is having the user to merge the two objects using: `Object.assign(console, timber.install(transport))`. Which is ugly and feels hacky IMO.

As a workaround, I simply added 2 internal options: `_attached_stdout` and `_attached_stderr`. They are automatically set to `true` when the `attach` function is run with either `stdout` or `stderr`. The `console` overrides will execute the original (unpatched) console functions unless the attached flag is raised.

So the updated console functions look [like this](https://github.com/timberio/timber-node/blob/conditional-console-overrides/src/console.js#L47-L65). The logic to detect when it's attached can be found [here](https://github.com/timberio/timber-node/blob/conditional-console-overrides/src/utils/attach.js#L55-L59).

It's the cleanest solution I could come up with to leave console unpatched until running `install(transport)`.