### PR TITLE
Catch network errors and report to debug logger

### DIFF
--- a/src/transports/https.js
+++ b/src/transports/https.js
@@ -94,6 +94,7 @@ class HTTPS extends Writable {
       res.on('close', () => debug('Response event: close'))
     })
 
+    req.on('error', (err) => debug('Error connecting to logs.timber.io:', err))
     req.on('abort', () => debug('Request event: abort'))
     req.on('aborted', () => debug('Request event: aborted'))
     req.on('connect', () => debug('Request event: connect'))


### PR DESCRIPTION
This will prevent applications from crashing when there is a network error connecting to `logs.timber.io`. It will report the error to the debug logger. Currently it's not possible to report errors back to `stderr` since they occur inside the https stream that is connected to `stderr`. So if we attempt to log a network error message to `stderr`, it will go in an infinite loop logging that message.

Ideally it would be nice to be able to alert them in the console so they're aware of network errors without having to install a debug logger, but I'll have to put more thought into how to accomplish that. But for now this fixes the crashing issue.