### PR TITLE
Preserve timestamp in Winston formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+  - Winston timestamps are now preserved when using the formatter
+
 ## [3.0.1] - 2017-09-20
 
 ### Fixed

--- a/src/formatters/winston.js
+++ b/src/formatters/winston.js
@@ -1,9 +1,13 @@
-import winston from 'winston'
 import Augment from '../utils/augment'
 import { Custom } from '../events'
-import errors from '../data/errors'
 
-const WinstonFormatter = ({ message, level, meta: metadata, timestamp }) => {
+const WinstonFormatter = ({
+  message: raw,
+  level,
+  meta: metadata,
+  timestamp,
+}) => {
+  const message = timestamp ? `${timestamp()} - ${raw}` : raw
   const structuredLog = new Augment(message, { level })
   const { event, context, ...meta } = metadata
 


### PR DESCRIPTION
This preserves the custom timestamp function added to winston.

related #62 