### PR TITLE
Remove message from metadata object

### DIFF
--- a/src/utils/augment.js
+++ b/src/utils/augment.js
@@ -60,22 +60,22 @@ class Augment {
    * i.e. `Log message @metadata { ... }`
    */
   format({ withMetadata = true } = {}) {
-    const { dt, ...rest } = this.data
+    const { dt, message, ...rest } = this.data
 
-    let message = this.raw.endsWith('\n')
+    let log = this.raw.endsWith('\n')
       ? this.raw.substring(0, this.raw.length - 1)
       : this.raw
 
     if (config.timestamp_prefix) {
-      message = `${dt.toISOString()} ${message}`
+      log = `${dt.toISOString()} ${log}`
     }
 
     if (withMetadata) {
       const data = config.timestamp_prefix ? rest : { dt, ...rest }
-      message += ` ${config.metadata_delimiter} ${JSON.stringify(data)}`
+      log += ` ${config.metadata_delimiter} ${JSON.stringify(data)}`
     }
 
-    return `${message}\n`
+    return `${log}\n`
   }
 }
 


### PR DESCRIPTION
When using `format()` on the `Augment` log class, the `message` will be removed from the `metadata` object. Since the message appears before `@metadata` it's a waste of bytes to display it twice.

closes #65 