### PR TITLE
Expose the LogEntry class for direct log building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+  - Exposes a new `LogEntry` class that can be used to build a structured log directly.
+
 ## [3.0.4] - 2017-10-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,9 +5,27 @@
 [![npm version](https://badge.fury.io/js/timber.svg)](https://badge.fury.io/js/timber)
 [![ISC License](https://img.shields.io/badge/license-ISC-ff69b4.svg)](LICENSE.md)
 
-Timber for Node is great Node logging made easy. It requires no changes to your existing logging
-statements, it automatically enhances your logs with context and metadata, and it pairs with the
-[Timber console](#the-timber-console) to deliver a highly productive logging experience.
+Node logging has problems. The average node project has libraries logging to the
+`console`, internal logs using [winston](https://github.com/winstonjs/winston) or
+[bunyan](https://github.com/trentm/node-bunyan), and frameworks logging in their own format.
+The end result is usually this:
+
+```
+192.442.345.32 - - [Mon, 09 Oct 2017 23:23:37 GMT] "GET / HTTP/1.1" 304 - "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36"
+Log message from console.warn
+{"level":"debug","message":"Log message from winston"}
+```
+
+Timber solves this by normalizing and augmenting your logs with structured data, *regardless of
+the source*. This not only normalizes your logs, but captures additional useful metadata:
+
+```
+GET / HTTP/1.1 @metadata {"dt": "2017-10-08T23:23:37.234Z", "level": "info", "context": {"http": {"remote_addr": "192.442.345.32"}}, "event": {"http_request": {"method": "GET", "path": "/", "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36"}}}
+Log message from console.warn @metadata {"dt": "2017-10-08T23:23:37.234Z", "level": "warn"}
+Log message from winston @metadata {"dt": "2017-10-08T23:23:37.234Z", "level": "debug"}
+```
+
+Ah! Consistent, easy to use logs. To get started:
 
 1. [**Installation** - Simple setup](#installation)
 2. [**Usage** - Clean API. Works with `console`, winston, and bunyan.](#usage)

--- a/src/console.js
+++ b/src/console.js
@@ -1,14 +1,32 @@
+/**
+ * @module timber/console
+ *
+ * This module transparently augments console messages with structured data. Continue
+ * to use `console` as you normally would and also pass an object as a second
+ * parameter to log structured data. In the examples below you will notice logs are
+ * appended with `@metadata ...`. This is what we mean by "augment". The timber.io
+ * service will strip and parse this data. See timber.io/docs for more details.
+ *
+ * @example <caption>Logging a string</caption>
+ * console.log('Hello world')
+ * // Hello world @metadata {'dt': '2017-10-09T02:42:12.235421Z', 'level': 'info', ...}
+ *
+ * @example <caption>Logging a structured data</caption>
+ * console.warn('Payent rejected', event: {payment_rejected: { customer_id: "abcd1234", amount: 100, reason: "Card expired" }})
+ * // Payent rejected @metadata {'dt': '2017-10-09T02:42:12.235421Z', 'level': 'warn', 'event': {'payment_rejected': {'customer_id': 'abcd1234', 'amount': 100, 'reason': 'Card expired'}}}
+ */
+
 import util from 'util'
-import Augment from './utils/augment'
 import config from './config'
+import LogEntry from './log_entry'
 
 /**
- * Transforms an ordinary console.log message into a structured Log object
+ * Transforms an ordinary console.log message into a structured Log object.
  * It also allows you to pass a Log object directly to a console.log function
  * It will automatically detect whether or not you are passing a structured
  * log into the console before attempting to transform it.
  *
- * This is also what is responsible for assigning the correct level to the log
+ * This is also what is responsible for assigning the correct level to the log.
  *
  * @param {Array} args - argument list passed to console
  * @param {String} level - `info` `warn` `error` `debug` `fatal`
@@ -22,17 +40,17 @@ const transformConsoleLog = ({ args, level }) => {
     typeof args[1] === 'object'
   ) {
     if (args[1].meta && typeof args[1].meta === 'object') {
-      return new Augment(args[0], { level, meta: { ...args[1].meta } }).format()
+      return new LogEntry(args[0], { level, meta: { ...args[1].meta } }).format()
     } else if (args[1].event && typeof args[1].event === 'object') {
-      return new Augment(args[0], {
+      return new LogEntry(args[0], {
         level,
         event: { custom: { ...args[1].event } },
       }).format()
     }
   }
-  const log = args[0] instanceof Augment
+  const log = args[0] instanceof LogEntry
     ? args[0]
-    : new Augment(`${util.format.apply(null, args)}\n`)
+    : new LogEntry(`${util.format.apply(null, args)}\n`)
   log.setLevel(level)
   return log.format()
 }

--- a/src/formatters/winston.js
+++ b/src/formatters/winston.js
@@ -1,5 +1,5 @@
-import Augment from '../utils/augment'
 import { Custom } from '../events'
+import LogEntry from '../log_entry'
 
 const WinstonFormatter = ({
   message: raw,
@@ -8,7 +8,7 @@ const WinstonFormatter = ({
   timestamp,
 }) => {
   const message = timestamp ? `${timestamp()} - ${raw}` : raw
-  const structuredLog = new Augment(message, { level })
+  const structuredLog = new LogEntry(message, { level })
   const { event, context, ...meta } = metadata
 
   // If custom metadata was provided with the log, append it

--- a/src/index.js
+++ b/src/index.js
@@ -7,17 +7,17 @@ import transports from './transports'
 import formatters from './formatters'
 import events from './events'
 import contexts from './contexts'
-import log from './log'
+import LogEntry from './log_entry'
 import './console'
 
 module.exports = {
   attach,
   config,
+  contexts,
+  events,
+  formatters,
   install,
+  LogEntry,
   middlewares,
   transports,
-  formatters,
-  log,
-  events,
-  contexts,
 }

--- a/src/log_entry.js
+++ b/src/log_entry.js
@@ -1,13 +1,15 @@
-import schema from '../schema'
-import config from '../config'
-import errors from '../data/errors'
+import config from './config'
+import errors from './data/errors'
+
+const JSON_SCHEMA_URL = 'https://raw.githubusercontent.com/timberio/log-event-json-schema/v3.1.3/schema.json';
 
 /**
+ * This class is instantiated before
  * Transforms a log message or object into a rich structured format
  * that timber expects, ex 'log message' @timber.io {"dt": "…", "level": "info", "context": {…}}
  * see https://github.com/timberio/log-event-json-schema for specs
  */
-class Augment {
+class LogEntry {
   /**
    * @param {String} message - the log message before transforming
    * @param {Object} [context] - context to be attached to message
@@ -27,11 +29,21 @@ class Augment {
      * @type {Date}
      */
     this.data = {
-      ...schema,
-      message,
+      $schema: JSON_SCHEMA_URL,
       dt: new Date(),
+      message,
       ...context,
     }
+  }
+
+  /**
+   * Adds the to the log entry. A log entry can only contain a single
+   * event.
+   *
+   * @param {Event} event
+   */
+  addEvent(event) {
+    this.append({event: event})
   }
 
   /**
@@ -79,4 +91,4 @@ class Augment {
   }
 }
 
-export default Augment
+export default LogEntry

--- a/src/middlewares/express.js
+++ b/src/middlewares/express.js
@@ -2,9 +2,9 @@
 import compose from 'composable-middleware'
 import addRequestId from 'express-request-id'
 import bodyParser from 'body-parser'
-import HTTP from '../contexts/http'
+import HTTPContext from '../contexts/http'
 import { HTTPRequest, HTTPResponse } from '../events'
-import log from '../log'
+import log from '../utils/log'
 import config from '../config'
 
 /**
@@ -56,7 +56,7 @@ const expressMiddleware = ({ ...options }) => {
         : undefined
 
       // create the HTTP context item
-      const http = new HTTP({
+      const http_context = new HTTPContext({
         method,
         path,
         request_id,
@@ -66,7 +66,7 @@ const expressMiddleware = ({ ...options }) => {
       // add the http context information to the metadata object
       const metadata = {
         context: {
-          http,
+          http_context,
         },
       }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,8 +1,0 @@
-// look into https://github.com/jquense/yup or
-// http://epoberezkin.github.io/ajv/#performancefor schema normalization/coercion
-
-export default {
-  $schema:
-    'https://raw.githubusercontent.com/timberio/log-event-json-schema/v3.1.1/schema.json',
-  message: '',
-}

--- a/src/transports/bunyan.js
+++ b/src/transports/bunyan.js
@@ -1,8 +1,8 @@
 import bunyan from 'bunyan'
 import { Writable } from 'stream'
 import { Custom } from '../events'
-import Augment from '../utils/augment'
 import errors from '../data/errors'
+import LogEntry from '../log_entry'
 
 /**
  * The Timber Bunyan transport allows you to seamlessly install
@@ -40,7 +40,7 @@ class BunyanTransport extends Writable {
     const level = bunyan.nameFromLevel[data.level]
 
     // Create a structured log object out of the log message
-    const structuredLog = new Augment(msg, { level })
+    const structuredLog = new LogEntry(msg, { level })
 
     // If custom metadata was provided with the log, append it
     if (meta && Object.keys(meta).length) {

--- a/src/transports/https.js
+++ b/src/transports/https.js
@@ -4,8 +4,7 @@ import debug from '../utils/debug'
 const HOSTNAME = 'logs.timber.io'
 const PATH = '/frames'
 const CONTENT_TYPE = 'application/json'
-const USER_AGENT = `Timber Node HTTPS Stream/${require('../../package.json')
-  .version}`
+const USER_AGENT = `Timber Node HTTPS Stream/${require('../../package.json').version}`
 const PORT = 443
 
 /**

--- a/src/utils/attach.js
+++ b/src/utils/attach.js
@@ -1,9 +1,9 @@
 import { Writable } from 'stream'
-import Augment from '../utils/augment'
 import { stripMetadata } from '../utils/metadata'
 import errors from '../data/errors'
 import config from '../config'
 import debug from './debug'
+import LogEntry from '../log_entry'
 
 /**
  * Attaches a transport stream to a writeable stream.
@@ -27,7 +27,7 @@ const attach = (transports, toStream, { applyBackPressure = false } = {}) => {
   debug(`attaching ${transports.length} transports to stream`)
 
   toStream.write = (message, encoding, fd) => {
-    const log = message instanceof Augment ? message : new Augment(message)
+    const log = message instanceof LogEntry ? message : new LogEntry(message)
 
     for (let i = 0; i < transports.length; i++) {
       const transport = transports[i]

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,12 +1,26 @@
-import Augment from './utils/augment'
-import config from './config'
+/*
+ * @private
+ *
+ * This module is meant to be *private* and should not be used directly.
+ * It's an internal function used by the Timber library to log within our
+ * integrations. It an abstraction on top of the various loggers our clients
+ * could use, ensuring we use the proper logger within each integration.
+ *
+ * For example, take Express. We provide a single middleware for capturing context
+ * and logging HTTP request and response events. We need to log to winston if the
+ * client is using winston, or the console if they are not. But a client should know
+ * which logger they are using and use that directly.
+ */
+
+import config from '../config'
+import LogEntry from '../log_entry'
 
 const loggers = {
   console: {
     detect: () => config.logger.constructor.name === 'Console' || config.logger.constructor.name === 'CustomConsole',
     handler: (level, message, metadata) => {
       if (metadata) {
-        return config.logger[level](new Augment(message, metadata))
+        return config.logger[level](new LogEntry(message, metadata))
       }
       return config.logger[level](message)
     },

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -1,18 +1,18 @@
-import Log from '../src/utils/augment';
+import LogEntry from '../src/log_entry';
 import config from '../src/config';
 
 describe('Log Transformer', () => {
   it('exports a function', () => {
-    expect(typeof Log).toBe('function');
+    expect(typeof LogEntry).toBe('function');
   });
 
   it('requires a message', () => {
-    expect(() => new Log()).toThrow();
+    expect(() => new LogEntry()).toThrow();
   });
 
   it('stores a data object', () => {
     const message = 'Test log line';
-    const log = new Log(message);
+    const log = new LogEntry(message);
 
     expect(typeof log.data).toBe('object');
     expect(log.data.message).toBe(message);
@@ -20,7 +20,7 @@ describe('Log Transformer', () => {
 
   it('append properly appends data values', () => {
     const message = 'Test log line';
-    const log = new Log(message);
+    const log = new LogEntry(message);
 
     log.append({ customAttribute: 'test' });
 
@@ -29,7 +29,7 @@ describe('Log Transformer', () => {
 
   it('append replaces existing data values', () => {
     const message = 'Test log line';
-    const log = new Log(message);
+    const log = new LogEntry(message);
 
     log.append({ level: 'error' });
     expect(log.data.level).toBe('error');
@@ -40,7 +40,7 @@ describe('Log Transformer', () => {
 
   it('setLevel properly sets the log level', () => {
     const message = 'Test log line';
-    const log = new Log(message);
+    const log = new LogEntry(message);
 
     expect(typeof log.setLevel).toBe('function');
 
@@ -51,7 +51,7 @@ describe('Log Transformer', () => {
 
   it('formats log properly', () => {
     const message = 'Test log line';
-    const log = new Log(message);
+    const log = new LogEntry(message);
     const regex = new RegExp(`${message} ${config.metadata_delimiter} {.*}`);
 
     expect(typeof log.format).toBe('function');
@@ -60,7 +60,7 @@ describe('Log Transformer', () => {
 
   it('format respects withMetadata option', () => {
     const message = 'Test log line';
-    const log = new Log(message);
+    const log = new LogEntry(message);
 
     expect(log.format({ withMetadata: false })).toBe(`${message}\n`);
   });


### PR DESCRIPTION
Like our other libraries, this exposes a `LogEntry` class which is used to build a structured log entry before sending to Timber. This should only be used directly in rare circumstances, as Timber integrates directly with the `console`, winston, and bunyan. You can use these directly to log structured data (see the README). As such, you should not be creating these objects directly except in exceptional circumstances.

An example of sending this event directly to Timber:

```js
const timber = require('timber')
const timber_transport = new timber.transports.HTTPS('your-api-key')

// Send logs
log_entry = new timber.LogEntry('my log message', {context: {http: {method: 'GET', request_id: 'abcd1234'}}})
timber_transport.write(log_entry.format());
```
