### PR TITLE
Add a manual CircleCI 2.0 definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+---
+version: 2
+jobs:
+  test:
+    docker:
+      - image: timberio/node-package-builder:1.0.0
+    working_directory: /opt/timber-node
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - timber-node-deps-{{ arch }}-{{ .Branch }}
+            - timber-node-deps-{{ arch }}-master
+      - run:
+          name: Install Project Dependencies
+          command: |
+            yarn install
+      - save_cache:
+          key: timber-node-deps-{{ arch }}-{{ .Branch }}-{{ epoch }}
+          paths:
+            - /opt/timber-node/node_modules
+      - run:
+          name: Run Test Suite
+          command: |
+            yarn test
+workflows:
+  version: 2
+  build:
+    jobs:
+      - test:
+          filters:
+            tags:
+              only: /.*/
+      - release:
+          filters:
+            tags:
+              only: /v.*/
+            branches:
+              ignore: /.*/
+          requires:
+            - test


### PR DESCRIPTION
This adds a manual definition of the CircleCI configuration rather than relying on the auto-detectionsystem. This will allow @zsherman to add the auto-documentation system and test it out on the Node repository.