### PR TITLE
Fix the link to the usage section for the console integration

### DIFF
--- a/docs/integrations/console.md
+++ b/docs/integrations/console.md
@@ -1,4 +1,4 @@
-Timber for Node ships with an integration for the standard JavaScript `console` functions. This integration allows you to either output standard logs or append logs with custom metadata or events using the builtin `console.log` functions. See [usage](../usage) for more details.
+Timber for Node ships with an integration for the standard JavaScript `console` functions. This integration allows you to either output standard logs or append logs with custom metadata or events using the builtin `console.log` functions. See [usage](../../usage) for more details.
 
 ## Installation
 


### PR DESCRIPTION
This fixes the link to the "Usage" section for the Console integration. The link was pointing up one relative directory when it needed to point up two.